### PR TITLE
Kollinstest

### DIFF
--- a/src/main/resources/assets/rf-capability-adapter/recipes/aecapabilityadapter.json
+++ b/src/main/resources/assets/rf-capability-adapter/recipes/aecapabilityadapter.json
@@ -10,8 +10,8 @@
       "item": "minecraft:iron_ingot"
     },
     "C": {
-      "type": "appliedenergistics2:part",
-      "part": "cable_dense_covered"
+      //This uses an ME Interface instead of a dense cable so it's craftable with or without channels enabled.
+      "type": "appliedenergistics2:interface",
     },
     "F": {
       "item": "#ae2:fluixCrystal"

--- a/src/main/resources/assets/rf-capability-adapter/recipes/aecapabilityadapter.json
+++ b/src/main/resources/assets/rf-capability-adapter/recipes/aecapabilityadapter.json
@@ -10,7 +10,6 @@
       "item": "minecraft:iron_ingot"
     },
     "C": {
-      //This uses an ME Interface instead of a dense cable so it's craftable with or without channels enabled.
       "type": "appliedenergistics2:interface",
     },
     "F": {


### PR DESCRIPTION
See also issue #3. Recipe change for the adapter to use an ME interface instead of a dense cable so it is a valid recipe whether or not AE2 settings have channels enabled. There appear to be no recipes close to conflicting with this in AE2, Extra Cells or AE2 Stuff.